### PR TITLE
Avoid crashes when processes list size is less than 10 elements.

### DIFF
--- a/src/ncurses_display.cpp
+++ b/src/ncurses_display.cpp
@@ -69,7 +69,8 @@ void NCursesDisplay::DisplayProcesses(std::vector<Process>& processes,
   mvwprintw(window, row, time_column, "TIME+");
   mvwprintw(window, row, command_column, "COMMAND");
   wattroff(window, COLOR_PAIR(2));
-  for (int i = 0; i < n; ++i) {
+  int const num_processes = int(processes.size()) > n ? n : processes.size();
+  for (int i = 0; i < num_processes; ++i) {
     mvwprintw(window, ++row, pid_column, to_string(processes[i].Pid()).c_str());
     mvwprintw(window, row, user_column, processes[i].User().c_str());
     float cpu = processes[i].CpuUtilization() * 100;


### PR DESCRIPTION
When the list of processes is empty or has less than 10 elements, the code will crash.

This change prevents this crash.